### PR TITLE
Enum handling + fixed tests on .Net 4.0

### DIFF
--- a/Source/Cvent.SchemaToPoco.Console/Cvent.SchemaToPoco.Console.csproj
+++ b/Source/Cvent.SchemaToPoco.Console/Cvent.SchemaToPoco.Console.csproj
@@ -57,10 +57,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NLog, Version=3.2.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NLog.3.2.0.0\lib\net40\NLog.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />

--- a/Source/Cvent.SchemaToPoco.Console/packages.config
+++ b/Source/Cvent.SchemaToPoco.Console/packages.config
@@ -2,5 +2,4 @@
 <packages>
   <package id="NDesk.Options" version="0.2.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net40" />
-  <package id="NLog" version="3.2.0.0" targetFramework="net40" />
 </packages>

--- a/Source/Cvent.SchemaToPoco.Core.UnitTests/Cvent.SchemaToPoco.Core.UnitTests.csproj
+++ b/Source/Cvent.SchemaToPoco.Core.UnitTests/Cvent.SchemaToPoco.Core.UnitTests.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Cvent.SchemaToPoco.Core.UnitTests</RootNamespace>
     <AssemblyName>Cvent.SchemaToPoco.Core.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -32,9 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -71,18 +71,14 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Cvent.SchemaToPoco.Console\Cvent.SchemaToPoco.Console.csproj">
-      <Project>{3aeffcc7-e21d-4699-b40e-09cb2965f328}</Project>
-      <Name>Cvent.SchemaToPoco.Console</Name>
-    </ProjectReference>
     <ProjectReference Include="..\Cvent.SchemaToPoco.Core\Cvent.SchemaToPoco.Core.csproj">
-      <Project>{B504BB29-7224-4F82-80ED-BDB344ACABEF}</Project>
+      <Project>{b504bb29-7224-4f82-80ed-bdb344acabef}</Project>
       <Name>Cvent.SchemaToPoco.Core</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>"..\..\..\packages\NUnit.Runners.2.6.3\tools\nunit-console.exe" $(TargetPath)</PostBuildEvent>
+    <PostBuildEvent>"..\..\..\packages\NUnit.Runners.2.6.4\tools\nunit-console.exe" $(TargetPath)</PostBuildEvent>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/Source/Cvent.SchemaToPoco.Core.UnitTests/FunctionalTests/EnumTest.cs
+++ b/Source/Cvent.SchemaToPoco.Core.UnitTests/FunctionalTests/EnumTest.cs
@@ -20,23 +20,36 @@ namespace Cvent.SchemaToPoco.Core.UnitTests.FunctionalTests
             const string correctResult = @"namespace generated
 {
     using System;
-
-
+    using generated;
     public enum Foo
-    {
+        {
 
-        One,
+            One,
 
-        _2two2,
+            _2two2,
 
-        Three__third_,
-    }
+            Three__third_,
+        }
 
     public class DefaultClassName
     {
+        private Foo _foo;
+
+
+        public virtual Foo Foo
+        {
+            get
+            {
+                return _foo;
+            }
+            set
+            {
+                _foo = value;
+            }
+        }
+
     }
 }";
-
             TestBasicEquals(correctResult, JsonSchemaToPoco.Generate(schema));
         }
     }

--- a/Source/Cvent.SchemaToPoco.Core.UnitTests/packages.config
+++ b/Source/Cvent.SchemaToPoco.Core.UnitTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net40" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>

--- a/Source/Cvent.SchemaToPoco.Core/Cvent.SchemaToPoco.Core.csproj
+++ b/Source/Cvent.SchemaToPoco.Core/Cvent.SchemaToPoco.Core.csproj
@@ -33,10 +33,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NLog">
+    <Reference Include="NLog, Version=3.2.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NLog.3.2.0.0\lib\net40\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />

--- a/Source/Test/App.config
+++ b/Source/Test/App.config
@@ -1,7 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-
+<?xml version="1.0"?>
 <configuration>
 	<startup>
-		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/>
 	</startup>
 </configuration>

--- a/Source/Test/Test.csproj
+++ b/Source/Test/Test.csproj
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Test</RootNamespace>
     <AssemblyName>Test</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -36,7 +37,7 @@
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/Source/Test/packages.config
+++ b/Source/Test/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
We didn't have .NET 4.5 available on the build server so in a prior commit I changed this project to use .NET 4.0, but I hadn't updated the unit tests, that's what the "get tests running on .NET 4.0" is about here.

The Enum issue I'm fixing is that previously Enum type declarations would be generated, but not the field & property using that enum type. So I'm adding the property/field generation as well. I'm also fixing up the handling of default values for Enums, which would try to assign a string vs the Enum. Note that I'm using Enum.Parse() in the generated code rather than an Enum literal since that allows a case-invariant comparison (since the generator is changing the case of Enum members from the schema declaration, but does not make the same change to the default values).

Below is an example of a generated DTO that includes Enums with a default value:

<pre>//------------------------------------------------------------------------------
// <auto-generated>
//     This code was generated by a tool.
//     Runtime Version:4.0.30319.18444
//
//     Changes to this file may cause incorrect behavior and will be lost if
//     the code is regenerated.
// </auto-generated>
//------------------------------------------------------------------------------

namespace RusticiSoftware.ScormContentPlayer.api.model
{
    using System;
    using RusticiSoftware.ScormContentPlayer.api.model;
    
    
    // Optional parameter to specify how to authorize against the given postbackurl, can be 'form' or 'httpbasic'. If form authentication, the username and password for authentication are submitted as form fields 'username' and 'password', and the registration data as the form field 'data'. If httpbasic authentication is used, the username and password are placed in the standard Authorization HTTP header, and the registration data is the body of the message (sent as text/xml content type). This field is set to 'form' by default.
    public enum AuthType
    {
        
        Form,
        
        Httpbasic,
    }
    
    // This parameter allows you to specify a level of detail in the information that is posted back while the course is being taken. It may be one of three values: 'course' (course summary), 'activity' (activity summary, or 'full' (full detail), and is set to 'course' by default. The information will be posted as xml, and the format of that xml is specified below under the method 'getRegistrationResult'
    public enum ResultsFormat
    {
        
        Course,
        
        Activity,
        
        Full,
    }
    
    // Specifies a URL for which to post activity and status data in real time as the course is completed.
    public class PostBack
    {
        
        private string _url;
        
        // Optional parameter to specify how to authorize against the given postbackurl, can be 'form' or 'httpbasic'. If form authentication, the username and password for authentication are submitted as form fields 'username' and 'password', and the registration data as the form field 'data'. If httpbasic authentication is used, the username and password are placed in the standard Authorization HTTP header, and the registration data is the body of the message (sent as text/xml content type). This field is set to 'form' by default.
        private AuthType _authType;
        
        // The user name to be used in authorizing the postback of data to the URL specified by postback url.
        private string _userName;
        
        // The password to be used in authorizing the postback of data to the URL specified by postback url.
        private string _password;
        
        // This parameter allows you to specify a level of detail in the information that is posted back while the course is being taken. It may be one of three values: 'course' (course summary), 'activity' (activity summary, or 'full' (full detail), and is set to 'course' by default. The information will be posted as xml, and the format of that xml is specified below under the method 'getRegistrationResult'
        private ResultsFormat _resultsFormat;
        
        public PostBack()
        {
            _authType = ((AuthType)(System.Enum.Parse(typeof(AuthType), "form", true)));
            _resultsFormat = ((ResultsFormat)(System.Enum.Parse(typeof(ResultsFormat), "course", true)));
        }
        
        public virtual string Url
        {
            get
            {
                return _url;
            }
            set
            {
                _url = value;
            }
        }
        
        // Optional parameter to specify how to authorize against the given postbackurl, can be 'form' or 'httpbasic'. If form authentication, the username and password for authentication are submitted as form fields 'username' and 'password', and the registration data as the form field 'data'. If httpbasic authentication is used, the username and password are placed in the standard Authorization HTTP header, and the registration data is the body of the message (sent as text/xml content type). This field is set to 'form' by default.
        public virtual AuthType AuthType
        {
            get
            {
                return _authType;
            }
            set
            {
                _authType = value;
            }
        }
        
        // The user name to be used in authorizing the postback of data to the URL specified by postback url.
        public virtual string UserName
        {
            get
            {
                return _userName;
            }
            set
            {
                _userName = value;
            }
        }
        
        // The password to be used in authorizing the postback of data to the URL specified by postback url.
        public virtual string Password
        {
            get
            {
                return _password;
            }
            set
            {
                _password = value;
            }
        }
        
        // This parameter allows you to specify a level of detail in the information that is posted back while the course is being taken. It may be one of three values: 'course' (course summary), 'activity' (activity summary, or 'full' (full detail), and is set to 'course' by default. The information will be posted as xml, and the format of that xml is specified below under the method 'getRegistrationResult'
        public virtual ResultsFormat ResultsFormat
        {
            get
            {
                return _resultsFormat;
            }
            set
            {
                _resultsFormat = value;
            }
        }
    }
}
</pre>
