### PR TITLE
Fix self-referencing schemas

### DIFF
--- a/Source/Cvent.SchemaToPoco.Core/JsonSchemaResolver.cs
+++ b/Source/Cvent.SchemaToPoco.Core/JsonSchemaResolver.cs
@@ -245,7 +245,7 @@ namespace Cvent.SchemaToPoco.Core
         private string StandardizeReferences(Uri parentUri, string data, ICollection<string> ids)
         {
             var lines = new List<string>(data.Split('\n'));
-            var pattern = new Regex(@"(\""\$ref\""\s*:\s*\"")(.*)(\"")");
+            var pattern = new Regex(@"(""\$ref""\s*:\s*"")(.*)("")");
 
             for (int i = lines.Count - 1; i >= 0; i--)
             {
@@ -277,7 +277,7 @@ namespace Cvent.SchemaToPoco.Core
         {
             var ids = new List<string>();
             var lines = new List<string>(data.Split('\n'));
-            var idPattern = new Regex(@"(\""id\""\s*:\s*\"")(.*)(\"")");
+            var idPattern = new Regex(@"(""id""\s*:\s*"")(.*)(\"")");
             for (int i = lines.Count - 1; i >= 0; i--)
             {
                 if (idPattern.IsMatch(lines[i]))

--- a/Source/Cvent.SchemaToPoco.Core/JsonSchemaResolver.cs
+++ b/Source/Cvent.SchemaToPoco.Core/JsonSchemaResolver.cs
@@ -101,6 +101,8 @@ namespace Cvent.SchemaToPoco.Core
 
         private JsonSchemaWrapper ResolveSchemaHelper(Uri curr, Uri parent, string data)
         {
+            var ids = GetIds(data);
+            data = StandardizeReferences(parent, data, ids);
             var definition = new
             {
                 csharpType = string.Empty,
@@ -115,17 +117,24 @@ namespace Cvent.SchemaToPoco.Core
             {
                 // Get the full path to the file, and change the reference to match
                 string refName = match.Groups[1].Value;
-                if (!refName.EndsWith(".json"))
-                {
-                    refName += ".json";
-                }
                 var currPath = new Uri(refName, UriKind.RelativeOrAbsolute);
+                if (ids.Contains(refName)) 
+                {
+                    //internal reference by ID, no need to load a new schema or add a dependency
+                    continue;
+                }
                 var currUri = IoUtils.GetAbsoluteUri(parent, currPath, true);
 
                 JsonSchemaWrapper schema;
 
                 if (!_schemas.ContainsKey(currUri))
                 {
+                    // if this is a self reference, no need to load anything or add a dependency
+                    if (parent.Equals(currUri))
+                    {
+                        continue;
+                    }
+
                     schema = ResolveSchemaHelper(parent, currUri);
                     _schemas.Add(currUri, schema);
                 }
@@ -175,7 +184,7 @@ namespace Cvent.SchemaToPoco.Core
 
             try
             {
-                parsed = JsonSchema.Parse(StandardizeReferences(parent, data), _resolver);
+                parsed = JsonSchema.Parse(data, _resolver);
             }
             catch (Exception)
             {
@@ -231,8 +240,9 @@ namespace Cvent.SchemaToPoco.Core
         /// </summary>
         /// <param name="parentUri">The parent Uri to resolve relative paths against.</param>
         /// <param name="data">The JSON schema.</param>
+        /// <param name="ids">the list of IDs defined in this schema</param>
         /// <returns>The JSON schema with standardized $ref attributes.</returns>
-        private string StandardizeReferences(Uri parentUri, string data)
+        private string StandardizeReferences(Uri parentUri, string data, ICollection<string> ids)
         {
             var lines = new List<string>(data.Split('\n'));
             var pattern = new Regex(@"(\""\$ref\""\s*:\s*\"")(.*)(\"")");
@@ -243,16 +253,45 @@ namespace Cvent.SchemaToPoco.Core
                 {
                     var matched = pattern.Match(lines[i]);
                     var matchedPath = matched.Groups[2].Value;
-                    if (!matchedPath.EndsWith(".json"))
+                    // only modify the reference if it's not referencing an ID in this file
+                    if (!ids.Contains(matchedPath))
                     {
-                        matchedPath += ".json";
+                        if (!matchedPath.EndsWith(".json"))
+                        {
+                            matchedPath += ".json";
+                        }
+                        var absPath = IoUtils.GetAbsoluteUri(parentUri, new Uri(matchedPath, UriKind.RelativeOrAbsolute), true);
+                        lines[i] = matched.Groups[1].Value + absPath + matched.Groups[3].Value + ",";
                     }
-                    var absPath = IoUtils.GetAbsoluteUri(parentUri, new Uri(matchedPath, UriKind.RelativeOrAbsolute), true);
-                    lines[i] = matched.Groups[1].Value + absPath + matched.Groups[3].Value + ",";
                 }
             }
 
-            return string.Join("\n", lines);
+            return string.Join(Environment.NewLine, lines);
+        }
+
+        /// <summary>
+        /// Build list of IDs defined in this file. Can be used to check if a reference
+        /// is referencing an ID (rather than an external file)
+        /// </summary>
+        private ICollection<string> GetIds(string data)
+        {
+            var ids = new List<string>();
+            var lines = new List<string>(data.Split('\n'));
+            var idPattern = new Regex(@"(\""id\""\s*:\s*\"")(.*)(\"")");
+            for (int i = lines.Count - 1; i >= 0; i--)
+            {
+                if (idPattern.IsMatch(lines[i]))
+                {
+                    ids.Add(idPattern.Match(lines[i]).Groups[2].Value);
+                }
+            }
+
+            // special ID for a self-reference
+            // NOTE: this syntax currently fails when we get to the parse step in Newtonsoft, but we should note it
+            //       as a valid ID here anyway as attempting to re-write such an entry won't help
+            ids.Add("#");
+
+            return ids;
         }
 
         /// <summary>

--- a/Source/Cvent.SchemaToPoco.Core/JsonSchemaToCodeUnit.cs
+++ b/Source/Cvent.SchemaToPoco.Core/JsonSchemaToCodeUnit.cs
@@ -197,6 +197,10 @@ namespace Cvent.SchemaToPoco.Core
                 
             };
 
+            // adding the autoprop declaration to the field name is a workaround as autoprops
+            // are otherwise unsupported by CodeMemberField. Unfortunately, this adds an
+            // extraneous ; at the end of the line, so the // hides that from the compiler
+            // and crucially hides it from CS2J
             field.Name += " { get; set; } //";
 
             return field;

--- a/Source/Cvent.SchemaToPoco.Core/JsonSchemaToCodeUnit.cs
+++ b/Source/Cvent.SchemaToPoco.Core/JsonSchemaToCodeUnit.cs
@@ -197,7 +197,7 @@ namespace Cvent.SchemaToPoco.Core
                 
             };
 
-            field.Name += " { get; set; }";
+            field.Name += " { get; set; } //";
 
             return field;
         }


### PR DESCRIPTION
External references weren't working  (which is needed in activityResultsSchema since each activity can have child activities), so this change fixes that, mainly by bypassing the "add .json" code where it's not needed.
