### PR TITLE
Include description comments as XML doc summary

### DIFF
--- a/Source/Cvent.SchemaToPoco.Core/Wrappers/BaseWrapper.cs
+++ b/Source/Cvent.SchemaToPoco.Core/Wrappers/BaseWrapper.cs
@@ -31,7 +31,7 @@ namespace Cvent.SchemaToPoco.Core.Wrappers
         /// <param name="s">The comment.</param>
         public void AddComment(string s)
         {
-            _property.Comments.Add(new CodeCommentStatement(s));
+            _property.Comments.Add(new CodeCommentStatement( "<summary>" + s + "</summary>", true));
         }
 
         /// <summary>


### PR DESCRIPTION
Tested by including in Engine and noting descriptions show up as XML comments, as expected.