### PR TITLE
Added type mapping for nullable numbers in php

### DIFF
--- a/Source/Cvent.SchemaToPoco.Core/CodeToLanguage/PhpCodeGenerator.cs
+++ b/Source/Cvent.SchemaToPoco.Core/CodeToLanguage/PhpCodeGenerator.cs
@@ -33,6 +33,7 @@ namespace Cvent.SchemaToPoco.Core.CodeToLanguage
             _typeMapping.Add("list<string>", "string[]");
             _typeMapping.Add("list<int>", "int[]");
             _typeMapping.Add("list<double>", "float[]");
+            _typeMapping.Add("system.object", "float|null");
 
         }
         public bool IsValidIdentifier(string value)


### PR DESCRIPTION
In the objective schema, some of the values are of type `["number", "null"]`, meaning that they can be a number or null. Our library doesn't quite know how to handle that array, and so defaults the type to `system.Object`, which then breaks whenever you need to create something from that schema.

I tried tracking down where this library actually reads the type parameter and determines what to set it as in the schema code, but couldn't figure it out, so I added this change as a workaround.