### PR TITLE
fix for latest mono

### DIFF
--- a/Source/Cvent.SchemaToPoco.Core.UnitTests/Cvent.SchemaToPoco.Core.UnitTests.csproj
+++ b/Source/Cvent.SchemaToPoco.Core.UnitTests/Cvent.SchemaToPoco.Core.UnitTests.csproj
@@ -35,8 +35,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Source/Cvent.SchemaToPoco.Core.UnitTests/packages.config
+++ b/Source/Cvent.SchemaToPoco.Core.UnitTests/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net40" requireReinstallation="True" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>

--- a/Source/Cvent.SchemaToPoco.Core/JsonSchemaToPoco.cs
+++ b/Source/Cvent.SchemaToPoco.Core/JsonSchemaToPoco.cs
@@ -74,7 +74,7 @@ namespace Cvent.SchemaToPoco.Core
         {
             var coloredConsoleTarget = new ColoredConsoleTarget
             {
-                Layout = "${date:format=yyyy-MM-dd} ${time:format=hh:mm:ss} [${level}] ${message}"
+                Layout = "${time:format=hh:mm:ss} [${level}] ${message}"
             };
             var loggingRule = new LoggingRule("*", LogLevel.Debug, coloredConsoleTarget);
             LogManager.Configuration = new LoggingConfiguration();


### PR DESCRIPTION
update references so solution builds in visual studio
when we catch a top level error, just write it to the console instead of
 trying to log, so even if error was in the logger we'll get the error
 message
remove log format that was breaking on latest mono